### PR TITLE
Silence stub-file warnings/notes.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2746,6 +2746,9 @@ public class AnnotationFileParser {
    * @param warning a warning message
    */
   private void warn(@Nullable NodeWithRange<?> astNode, String warning) {
+    if (true) {
+      return;
+    }
     if (fileType != AnnotationFileType.JDK_STUB) {
       if (warnings.add(warning)) {
         processingEnv


### PR DESCRIPTION
@cushon 

(I've been going with `if (true) { return; }` over commenting out or deleting the method implementation. My hope is that that will minimize the number of future merge conflicts when we pull changes from upstream.)