### PR TITLE
Make the build script fetch related repos unshallowly and with all branches

### DIFF
--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -31,14 +31,14 @@ else
 fi
 
 # Clone the annotated JDK into ../jdk .
-"$PLUME_SCRIPTS/git-clone-related" typetools jdk
+"$PLUME_SCRIPTS/git-clone-related" typetools jdk -q
 
 AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
 # Don't use `AT=${AFU}/..` which causes a git failure.
 AT=$(dirname "${AFU}")
 
 ## Build annotation-tools (Annotation File Utilities)
-"$PLUME_SCRIPTS/git-clone-related" typetools annotation-tools "${AT}"
+"$PLUME_SCRIPTS/git-clone-related" typetools annotation-tools "${AT}" -q
 if [ ! -d ../annotation-tools ] ; then
   ln -s "${AT}" ../annotation-tools
 fi
@@ -49,14 +49,14 @@ echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 
 ## Build stubparser
-"$PLUME_SCRIPTS/git-clone-related" typetools stubparser
+"$PLUME_SCRIPTS/git-clone-related" typetools stubparser -q
 echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
 (cd ../stubparser/ && ./.build-without-test.sh)
 echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
 
 
 ## Build JSpecify, only for the purpose of using its tests.
-"$PLUME_SCRIPTS/git-clone-related" jspecify jspecify
+"$PLUME_SCRIPTS/git-clone-related" jspecify jspecify -q
 if type -p java; then
   _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -31,7 +31,7 @@ else
 fi
 
 # Clone the annotated JDK into ../jdk .
-"$PLUME_SCRIPTS/git-clone-related" typetools jdk -q
+"$PLUME_SCRIPTS/git-clone-related" typetools jdk
 
 AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
 # Don't use `AT=${AFU}/..` which causes a git failure.


### PR DESCRIPTION
`git-clone-related` uses default arguments `-q --single-branch --depth 1`, By specifying `-q` we can get deep fetches and all branches.