### PR TITLE
Check out the stubparser commit that corresponds to the version we need to build (3.24.2).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,6 +316,12 @@ task maybeCloneAndBuildDependencies() {
                 args = ['pull', '-q']
                 ignoreExitValue = true
             }
+            // check out the version corresponding to 3.24.2.
+            exec {
+                workingDir stubparser
+                executable 'git'
+                args = ['checkout', 'dd2c1d4a8b3c428d554d6fab6aa1b840d4031985', '-q']
+            }
             exec {
                 workingDir stubparser
                 executable "${stubparser}/.build-without-test.sh"


### PR DESCRIPTION
This will allow us to remove another manual step in building nullness-checker-for-checker-framework.