### PR TITLE
Suppress "temporary" deprecation warnings/errors

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -129,6 +129,7 @@ public final class SceneToStubWriter {
    * @param a the annotation to print
    * @return the formatted annotation
    */
+  @SuppressWarnings("deprecation") // AnnotationFieldType.format(Object) is *temporarily* deprecated.
   public static String formatAnnotation(Annotation a) {
     String fullAnnoName = a.def().name;
     String simpleAnnoName = fullAnnoName.substring(fullAnnoName.lastIndexOf('.') + 1);


### PR DESCRIPTION
`AnnotationFieldType.format(Object)` was "temporarily" deprecated recently, and we build with `-Werror`, so we break if this isn't suppressed.