### PR TITLE
Pin commits for annotation-tools and stubparser.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,12 +316,6 @@ task maybeCloneAndBuildDependencies() {
                 args = ['pull', '-q']
                 ignoreExitValue = true
             }
-            // check out the version corresponding to 3.24.2.
-            exec {
-                workingDir stubparser
-                executable 'git'
-                args = ['checkout', 'dd2c1d4a8b3c428d554d6fab6aa1b840d4031985', '-q']
-            }
             exec {
                 workingDir stubparser
                 executable "${stubparser}/.build-without-test.sh"

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -43,7 +43,7 @@ if [ ! -d ../annotation-tools ] ; then
   ln -s "${AT}" ../annotation-tools
 fi
 
-# check out the annotation-tools commit at which github.com/jspecify/checker-framework last merged from upstream.
+echo "Checking out the annotation-tools commit at which jspecify last merged from upstream."
 git -C "${AT}" checkout -q 7174291c828e88382758e0d5117f99418970f24f
 
 echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
@@ -54,7 +54,7 @@ echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 ## Build stubparser
 "$PLUME_SCRIPTS/git-clone-related" typetools stubparser -q
 
-# check out the stubparser version at which github.com/jspecify/checker-framework last merged from upstream.
+echo "Checking out the stubparser commit at which jspecify last merged from upstream."
 git -C ../stubparser checkout -q dd2c1d4a8b3c428d554d6fab6aa1b840d4031985
 
 echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -43,6 +43,9 @@ if [ ! -d ../annotation-tools ] ; then
   ln -s "${AT}" ../annotation-tools
 fi
 
+# check out the annotation-tools commit at which github.com/jspecify/checker-framework last merged from upstream.
+git -C "${AT}" checkout -q 7174291c828e88382758e0d5117f99418970f24f
+
 echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
 (cd "${AT}" && ./.build-without-test.sh)
 echo "... done: (cd ${AT} && ./.build-without-test.sh)"
@@ -50,6 +53,10 @@ echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 ## Build stubparser
 "$PLUME_SCRIPTS/git-clone-related" typetools stubparser -q
+
+# check out the stubparser version at which github.com/jspecify/checker-framework last merged from upstream.
+git -C ../stubparser checkout -q dd2c1d4a8b3c428d554d6fab6aa1b840d4031985
+
 echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
 (cd ../stubparser/ && ./.build-without-test.sh)
 echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -129,7 +129,6 @@ public final class SceneToStubWriter {
    * @param a the annotation to print
    * @return the formatted annotation
    */
-  @SuppressWarnings("deprecation") // AnnotationFieldType.format(Object) is *temporarily* deprecated.
   public static String formatAnnotation(Annotation a) {
     String fullAnnoName = a.def().name;
     String simpleAnnoName = fullAnnoName.substring(fullAnnoName.lastIndexOf('.') + 1);


### PR DESCRIPTION
This way developers will not get spurious build errors.