### PR TITLE
Teach the old-style samples test that lines with `test:cannot-convert` indicate expected diagnostics.

### DIFF
--- a/framework-test/src/main/java/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
@@ -351,12 +351,8 @@ public class TestDiagnosticUtils {
               true);
       return new TestDiagnosticLine(
           filename, lineNumber, line, Collections.singletonList(diagnostic));
-    } else if (trimmedLine.startsWith("// jspecify_")) {
-      TestDiagnostic diagnostic =
-          fromJSpecifyFileComment(filename, errorLine, trimmedLine.substring(3));
-      return new TestDiagnosticLine(
-          filename, errorLine, line, Collections.singletonList(diagnostic));
-    } else if (trimmedLine.startsWith("// test:cannot-convert")) {
+    } else if (trimmedLine.startsWith("// jspecify_")
+        || trimmedLine.startsWith("// test:cannot-convert")) {
       TestDiagnostic diagnostic =
           fromJSpecifyFileComment(filename, errorLine, trimmedLine.substring(3));
       return new TestDiagnosticLine(

--- a/framework-test/src/main/java/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
@@ -356,6 +356,11 @@ public class TestDiagnosticUtils {
           fromJSpecifyFileComment(filename, errorLine, trimmedLine.substring(3));
       return new TestDiagnosticLine(
           filename, errorLine, line, Collections.singletonList(diagnostic));
+    } else if (trimmedLine.startsWith("// test:cannot-convert")) {
+      TestDiagnostic diagnostic =
+          fromJSpecifyFileComment(filename, errorLine, trimmedLine.substring(3));
+      return new TestDiagnosticLine(
+          filename, errorLine, line, Collections.singletonList(diagnostic));
     } else {
       // It's a bit gross to create empty diagnostics (returning null might be more
       // efficient), but they will be filtered out later.


### PR DESCRIPTION
This is necessary before we can merge `main` into
`samples-google-prototype`.
