### PR TITLE
Actually build the stubparser

### DIFF
--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -39,11 +39,9 @@ fi
 echo "Checking out the stubparser commit at which jspecify last merged from upstream."
 git -C ../stubparser checkout -q dd2c1d4a8b3c428d554d6fab6aa1b840d4031985
 
-if false; then # DO NOT BUILD DURING THE BUILD
-  echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
-  (cd ../stubparser/ && ./.build-without-test.sh)
-  echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
-fi
+echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
+(cd ../stubparser/ && ./.build-without-test.sh)
+echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
 
 
 ## Build JSpecify, only for the purpose of using its tests.


### PR DESCRIPTION
This PR should fix the CI failure in https://github.com/jspecify/jspecify-reference-checker/pull/113.

The cryptic message is:

````
A problem occurred starting process 'command 'ls''
````

Which is likely caused by https://github.com/jspecify/checker-framework/blob/24aca9efe48a4d31e33284e21c4ee27bb9f76e44/build.gradle#L330

To reproduce the problem locally, remove the `stubparser` directory and run `./gradlew assemble` either here in the `checker-framework` or in the `jspecify-reference-checker`. You should see the same failure as in CI.

This PR undoes parts of the changes in https://github.com/jspecify/checker-framework/commit/c92af7df8dc31bb563216918c6d69173f85c7f9f.

I'm also not sure why this issue only arises with https://github.com/jspecify/jspecify-reference-checker/pull/113, maybe some gradle behavior changed?

