### PR TITLE
Depend on released stubparser artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,6 @@ ext {
 
     parentDir = file("${rootDir}/../").absolutePath
 
-    stubparser = "${parentDir}/stubparser"
-    stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.24.2.jar"
-
     jtregHome = "${parentDir}/jtreg"
     formatScriptsHome = "${project(':checker').projectDir}/bin-devel/.run-google-java-format"
     plumeScriptsHome = "${project(':checker').projectDir}/bin-devel/.plume-scripts"
@@ -294,45 +291,6 @@ allprojects {
 task cloneAndBuildDependencies(type: Exec, group: 'Build') {
     description 'Clones (or updates) and builds all dependencies'
     executable 'checker/bin-devel/build.sh'
-}
-
-task maybeCloneAndBuildDependencies() {
-    // No group so it does not show up in the output of `gradlew tasks`
-    description 'Clones (or updates) and builds all dependencies if they are not present.'
-    onlyIf {
-        !file(stubparserJar).exists()
-        // The jdk repository is cloned via the copyAndMinimizeAnnotatedJdkFiles task that is run if
-        // the repository does not exist when building checker.jar.
-    }
-
-    doFirst {
-        if (file(stubparser).exists()) {
-            exec {
-                workingDir stubparser
-                executable 'git'
-                args = ['pull', '-q']
-                ignoreExitValue = true
-            }
-            exec {
-                workingDir stubparser
-                executable "${stubparser}/.build-without-test.sh"
-            }
-        } else {
-            exec {
-                executable 'checker/bin-devel/build.sh'
-            }
-        }
-    }
-    doLast {
-        if (!file(stubparserJar).exists()) {
-            exec {
-                workingDir "${stubparser}/javaparser-core/target"
-                executable 'ls'
-                ignoreExitValue = true
-            }
-            throw new RuntimeException("Can't find stubparser jar: " + stubparserJar)
-        }
-    }
 }
 
 task version(group: 'Documentation') {

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -33,16 +33,18 @@ fi
 # Clone the annotated JDK into ../jdk .
 "$PLUME_SCRIPTS/git-clone-related" typetools jdk
 
-## Build stubparser
-"$PLUME_SCRIPTS/git-clone-related" typetools stubparser -q
+# DO NOT BUILD stubparser
+if false; then
+  ## Build stubparser
+  "$PLUME_SCRIPTS/git-clone-related" typetools stubparser -q
 
-echo "Checking out the stubparser commit at which jspecify last merged from upstream."
-git -C ../stubparser checkout -q dd2c1d4a8b3c428d554d6fab6aa1b840d4031985
+  echo "Checking out the stubparser commit at which jspecify last merged from upstream."
+  git -C ../stubparser checkout -q dd2c1d4a8b3c428d554d6fab6aa1b840d4031985
 
-echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
-(cd ../stubparser/ && ./.build-without-test.sh)
-echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
-
+  echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
+  (cd ../stubparser/ && ./.build-without-test.sh)
+  echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
+fi
 
 # DO NOT CLONE JSPECIFY
 if false; then

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -44,8 +44,9 @@ configurations {
 dependencies {
     api project(':javacutil')
     api project(':dataflow')
-    api files("${stubparserJar}")
     api project(':checker-qual')
+
+    api 'org.checkerframework:stubparser:3.25.6'
 
     // External dependencies:
     // If you add an external dependency, you must shadow its packages.
@@ -132,16 +133,6 @@ task copyAndMinimizeAnnotatedJdkFiles(dependsOn: cloneTypetoolsJdk, group: 'Buil
 sourcesJar.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
 
 processResources.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
-
-task checkDependencies(dependsOn: ':maybeCloneAndBuildDependencies') {
-    doLast {
-        if (!file(stubparserJar).exists()) {
-            throw new GradleException("${stubparserJar} does not exist. Try running './gradlew cloneAndBuildDependencies'")
-        }
-    }
-}
-
-compileJava.dependsOn(checkDependencies)
 
 task allSourcesJar(type: Jar, group: 'Build') {
     description 'Creates a sources jar that includes sources for all Checker Framework classes in framework.jar'

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2176,7 +2176,7 @@ public class AnnotationFileParser {
       }
     }
     if (!noWarn) {
-      if (methodDecl.getAccessSpecifier() == AccessSpecifier.PACKAGE_PRIVATE) {
+      if (methodDecl.getAccessSpecifier() == AccessSpecifier.NONE) {
         // This might be a false positive warning.  The stub parser permits a stub file to
         // omit the access specifier, but package-private methods aren't in the TypeElement.
         stubWarnNotFound(

--- a/framework/src/main/java/org/checkerframework/framework/stub/JavaStubifier.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/JavaStubifier.java
@@ -231,7 +231,7 @@ public class JavaStubifier {
         return false;
       }
       AccessSpecifier as = node.getAccessSpecifier();
-      if (as == AccessSpecifier.PRIVATE || as == AccessSpecifier.PACKAGE_PRIVATE) {
+      if (as == AccessSpecifier.PRIVATE || as == AccessSpecifier.NONE) {
         ((Node) node).remove();
         return true;
       }


### PR DESCRIPTION
I was tempted to set up a CI build, but hopefully this fork will be gone soon.
This just saves us from compiling the stubparser every time by depending on the released artifact.
There is only one small API change that affects two files.